### PR TITLE
Improve Configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ its development and thus there are some sharp edges.
   hardware so it seems unlikely that they will be supported going forward. Thus
   this project does not support them.
 
-- The aws-ena-driver-vanilla package is still in edge/testing.  When it is
-  available in a release, the edge/testing repository can be removed from
-  /etc/apk/repositories.
+- The aws-ena-driver-vanilla package is still in edge/testing, and requires the
+  matching linux-vanilla package from edge/main.  When ENA is available in an
+  alpine version release, edge/testing and edge/main should no longer be
+  necessary.
 
 - [cloud-init](https://cloudinit.readthedocs.io/en/latest/) is not currently
   supported on Alpine Linux. Instead this image uses

--- a/alpine-ami.yaml
+++ b/alpine-ami.yaml
@@ -1,84 +1,59 @@
 variables:
-  security_group: ""
-  subnet: ""
-  public_ip: "false"
 
-  # Treat this similar to a ABUILD pkgrel variable and increment with every
-  # release. Packer will notice an exiting AMI at build start and fail unless
-  # it is rmoved. To prevent a period of time where no Alpine AMI exists,
-  # create a new variant. Old AMIs should be pruned at some point.
-  ami_release: "0"
+  # NOTE:  Additional configuration is set via the `variables.json` file.
+  # To use default values, simply `cp variables.json-default variables.json`.
+  # See `variables.json-example` for full configuration variable descriptions.
 
-  # Overriding this requires validating that the installation script still
-  # works as expected. It probably does but stuff changes between major
-  # version.
+  # NOTE:  Changing alpine_release requires modifying `make_ami.sh` -- don't
+  # override this in `variables.json`!
   alpine_release: "3.8"
 
-  # Don't override this without a good reason and if you do just make sure it
-  # gets passed all the way through to the make_ami script
-  volume_name: "/dev/xvdf"
 
 builders:
   - type: "amazon-ebssurrogate"
 
-    # Image is built inside a custom VPC so let Packer use the existing
-    # resources
-    security_group_id: "{{user `security_group`}}"
-    subnet_id: "{{user `subnet`}}"
+    ### Builder Instance Details
 
-    # Input Instance Setting
-    instance_type: "t2.nano"
+    vpc_id: "{{user `vpc`}}"
+    subnet_id: "{{user `subnet`}}"
+    security_group_id: "{{user `security_group`}}"
+    instance_type: "{{user `build_instance_type`}}"
+    associate_public_ip_address: "{{user `public_ip`}}"
     launch_block_device_mappings:
       - volume_type: "gp2"
         device_name: "{{user `volume_name`}}"
-        delete_on_termination: true
-        volume_size: 1
-    associate_public_ip_address: "{{user `public_ip`}}"
-
-    # Output AMI Settings
-    ena_support: true
-    ami_name: "Alpine-{{user `alpine_release`}}-r{{user `ami_release`}}-EC2"
-    ami_description: "Alpine Linux {{user `alpine_release`}}-r{{user `ami_release`}} Release with EC2 Optimizations"
-    ami_groups:
-      - "all"
-    ami_virtualization_type: "hvm"
-    ami_regions:
-      - us-east-1
-      - us-east-2
-      - us-west-1
-      - us-west-2
-      - ca-central-1
-      - eu-central-1
-      - eu-west-1
-      - eu-west-2
-      - eu-west-3
-      - ap-northeast-1
-      - ap-northeast-2
-#      - ap-northeast-3
-      - ap-southeast-1
-      - ap-southeast-2
-      - ap-south-1
-      - sa-east-1
-    ami_root_device:
-      source_device_name: "{{user `volume_name`}}"
-      device_name: "/dev/xvda"
-      delete_on_termination: true
-      volume_size: 1
-      volume_type: "gp2"
-
-    # Use the most recent Amazon Linux AMI as our base
+        delete_on_termination: "true"
+        volume_size: "{{user `volume_size`}}"
     ssh_username: "ec2-user"
     source_ami_filter:
+      # use the latest Amazon Linux AMI
       filters:
         virtualization-type: "hvm"
         root-device-type: "ebs"
         architecture: "x86_64"
         name: "amzn-ami-hvm-*-x86_64-gp2"
-      owners: 
+      owners:
         - "137112412989"
-      most_recent: true
+      most_recent: "true"
+
+    ### Built AMI Details
+
+    ami_name: "{{user `ami_name_prefix`}}{{user `alpine_release`}}-r{{user `ami_release`}}{{user `ami_name_suffix`}}"
+    ami_description: "{{user `ami_desc_prefix`}}{{user `alpine_release`}}-r{{user `ami_release`}}{{user `ami_desc_suffix`}}"
+    ami_virtualization_type: "hvm"
+    ami_root_device:
+      source_device_name: "{{user `volume_name`}}"
+      device_name: "/dev/xvda"
+      delete_on_termination: "true"
+      volume_size: "{{user `volume_size`}}"
+      volume_type: "gp2"
+    ena_support: "{{user `ena_enable`}}"
+    sriov_support: "{{user `sriov_enable`}}"
+    ami_groups: "{{user `ami_access`}}"
+    ami_regions: "{{user `deploy_regions`}}"
+
 
 provisioners:
   - type: "shell"
     script: "make_ami.sh"
-    execute_command: "sudo sh -c '{{ .Vars }} {{ .Path }} {{user `volume_name`}}'"
+    execute_command: 'sudo sh -c "{{ .Vars }} {{ .Path }} {{user `volume_name`}} {{user `kernel_flavor`}} ''{{user `add_repos`}}'' ''{{user `add_pkgs`}}''"'

--- a/variables.json-default
+++ b/variables.json-default
@@ -1,0 +1,22 @@
+{
+  "ami_release": "1",
+  "ami_name_prefix": "Alpine-",
+  "ami_name_suffix": "-EC2",
+  "ami_desc_prefix": "Alpine Linux ",
+  "ami_desc_suffix": " Release with EC2 Optimizations",
+  "kernel_flavor": "vanilla@edge-main",
+  "add_repos": "@edge-main http://dl-cdn.alpinelinux.org/alpine/edge/main,@edge-testing http://dl-cdn.alpinelinux.org/alpine/edge/testing",
+  "add_pkgs": "acct aws-ena-driver-vanilla@edge-testing",
+  "ena_enable": "true",
+  "sriov_enable": "false",
+  "volume_size": "1",
+  "ami_access": "all",
+  "deploy_regions": "us-east-1,us-east-2,us-west-1,us-west-2,ca-central-1,eu-central-1,eu-west-1,eu-west-2,eu-west-3,ap-northeast-1,ap-northeast-2,ap-southeast-1,ap-southeast-2,ap-south-1,sa-east-1",
+
+  "vpc": "",
+  "subnet": "",
+  "security_group": "",
+  "public_ip": "false",
+  "build_instance_type": "t2.nano",
+  "volume_name": "/dev/xvdf"
+}

--- a/variables.json-example
+++ b/variables.json-example
@@ -1,0 +1,72 @@
+# NOTE: This is file not valid JSON.
+{
+  ### Build Options ###
+
+  # Treat similar to a ABUILD pkgrel variable and increment with every release.
+  "ami_release": "1",
+
+  # AMI name prefix and suffix
+  "ami_name_prefix": "Alpine-",
+  "ami_name_suffix": "-EC2",
+
+  # AMI description prefix and suffix
+  "ami_desc_prefix": "Alpine Linux ",
+  "ami_desc_suffix": " Release with EC2 Optimizations",
+
+  # Kernel "flavor" to install.  'virt' is a slim choice, but doesn't currently
+  # include NVME support and there is no matching 'aws-ena-driver' package.
+  # 'vanilla' installs a lot of unneeded stuff (for an AMI), but does support
+  # NVME; however, there is no matching ENA driver in the main repo.  In order
+  # to support NVME and ENA, we need to use 'vanilla@edge-main', which matches
+  # the 'aws-ena-driver@edge-testing' package.
+  "kernel_flavor": "vanilla@edge-main",
+
+  # Comma separated list of lines to add to /etc/apk/repositories.  We need
+  # edge/main and edge/testing for simultaneous NVME and ENA support.
+  "add_repos": "@edge-main http://dl-cdn.alpinelinux.org/alpine/edge/main,@edge-testing http://dl-cdn.alpinelinux.org/alpine/edge/testing",
+
+  # Space separated list of additional packages to add to the AMI.
+  # acct - system accounting utilities (sa, etc.)
+  # aws-ena-driver-vanilla - Enhanced Network Adapter kernel module
+  "add_pkgs": "acct aws-ena-driver-vanilla@edge-testing",
+
+  # Enable ENA/SRIOV support on the AMI.
+  "ena_enable": "true",
+  "sriov_enable": "false",
+
+  # Size of the AMI image (in GiB).
+  "volume_size": "1",
+
+  # Comma separated list of groups that should have access to the AMI.  However,
+  # only two values are currently supported: 'all' for public, '' for private.
+  "ami_access": "all",
+
+  # Comma separated list of regions to where the AMI should be copied.
+  # NOTE: ap-northeast-3 skipped, as it is available by subscription-only.
+  "deploy_regions": "us-east-1,us-east-2,us-west-1,us-west-2,ca-central-1,eu-central-1,eu-west-1,eu-west-2,eu-west-3,ap-northeast-1,ap-northeast-2,ap-southeast-1,ap-southeast-2,ap-south-1,sa-east-1",
+
+
+  ### Builder-Instance Options ###
+
+  # VPC in which the builder instance is to be launched; you must also provide
+  # a subnet.
+  "vpc": "",
+
+  # Subnet in which the builder instance is to be launched.
+  "subnet": "",
+
+  # Security group to apply to the builder instance.
+  "security_group": "",
+
+  # Assign a public IP to the builder instance.  Set to 'true' for if you need
+  # to initiate the build from somewhere that wouldn't normally be able to
+  # access the builder instance's private network.
+  "public_ip": "false",
+
+  # Instance type to use for building.
+  "build_instance_type": "t2.nano",
+
+  # Don't override this without a good reason, and if you do just make sure it
+  # gets passed all the way through to the make_ami script.
+  "volume_name": "/dev/xvdf"
+}


### PR DESCRIPTION
* move config variables from `alpine-ami.yaml` to `variables.json-*`
  + `variables.json-default` - ready-for-action original default config
  + `variables.json-example` - original defaults with comments
* clean up tabs vs. spaces in `make_ami.sh`
* `make_ami.sh` handles custom kernel flavor, extra repos, and extra packages
* tweak `README.md` with regards to aws-ena-driver caveat