### PR TITLE
Re-baseline to the newly-released Alpine 3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+**/*~
+**/*.swp
 /build/
 /.py3/
 /variables.yaml

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ami: convert
 	packer build -var-file=build/variables.json build/alpine-ami.json
 
 edge: convert
-	@echo '{ "alpine_release": "edge", "ami_release": "'`date +%Y%m%d%H%M%S`'" }' > build/edge.json
+	@echo '{ "version": "edge", "release": "edge", "revision": "'-`date +%Y%m%d%H%M%S`'" }' > build/edge.json
 	packer build -var-file=build/variables.json -var-file=build/edge.json build/alpine-ami.json
 
 convert: build/convert

--- a/README.md
+++ b/README.md
@@ -1,27 +1,29 @@
 # Alpine Linux EC2 AMI Build
 
-**NOTE: This is not an official Amazon or AWS provided image. This is community
-built and supported.**
+**NOTE: This is not an official Amazon or AWS provided image.  This is
+community built and supported.**
 
 This repository contains a packer file and a script to create an EC2 AMI
-containing Alpine Linux. The AMI is designed to work with most EC2 features
-such as Elastic Network Adapters and NVME EBS volumes by default. If anything
+containing Alpine Linux.  The AMI is designed to work with most EC2 features
+such as Elastic Network Adapters and NVME EBS volumes by default.  If anything
 is missing please report a bug.
 
-This image can be launched on any modern instance type, including T3, M5, C5,
-I3, R5, P3, X1, X1e, D2, Z1d. Other instances may also work but have not been
-tested. If you find an issue with instance support for any current generation
-instance please file a bug against this project.
+This image can be launched on any modern x86_64 instance type, including T3,
+M5, C5, I3, R5, P3, X1, X1e, D2, Z1d.  Other instances may also work but have
+not been tested.  If you find an issue with instance support for any current
+generation instance please file a bug against this project.
 
-To get started use one of the AMIs below. The default user is `alpine` and will
-be configured to use whatever SSH keys you chose when you launched the image.
-If user data is specified it must be a shell script that begins with `#!`. If a
-script is provided it will be executed as root after the network is configured.
+To get started use one of the AMIs below.  The default user is `alpine` and
+will be configured to use whatever SSH keys you chose when you launched the
+image.  If user data is specified it must be a shell script that begins with
+`#!`.  If a script is provided it will be executed as root after the network is
+configured.
 
-**Note:** This image will be updated as Alpine Linux changes over time and as
-AWS adds regions. This file and
+**NOTE:** *The images listed below are currently very much out of date.  We are
+working on providing a set of updated 3.9 AMIs for all current AWS regions, and
+hope to automate AMI builds and updates to this file and
 [release.yaml](https://github.com/mcrute/alpine-ec2-ami/blob/master/release.yaml)
-will be updated as new regions are made available.
+in the not-too-distant future.*
 
 | Alpine Version | Region Code | AMI ID |
 | -------------- | ----------- | ------ |
@@ -45,28 +47,22 @@ will be updated as new regions are made available.
 This image is being used in production but it's still somewhat early stage in
 its development and thus there are some sharp edges.
 
-- Only EBS-backed HVM instances are supported. While paravirtualized instances
+- Only EBS-backed HVM instances are supported.  While paravirtualized instances
   are still available from AWS they are not supported on any of the newer
-  hardware so it seems unlikely that they will be supported going forward. Thus
-  this project does not support them.
+  hardware so it seems unlikely that they will be supported going forward.
+  Thus this project does not support them.
 
 - [cloud-init](https://cloudinit.readthedocs.io/en/latest/) is not currently
-  supported on Alpine Linux. Instead this image uses
-  [tiny-ec2-bootstrap](https://github.com/mcrute/tiny-ec2-bootstrap). Hostname
-  setting will work as will setting the ssh keys for the Alpine user based on
-  what was configured during instance launch. User data is supported as long
-  as it's a shell script (starts with #!). See the tiny-ec2-bootstrap README
-  for more details. You can still install cloud-init (from the edge/3.9 testing
+  supported on Alpine Linux.  Instead this image uses
+  [tiny-ec2-bootstrap](https://github.com/mcrute/tiny-ec2-bootstrap).  Hostname
+  setting will work, as will setting the ssh keys for the Alpine user based on
+  what was configured during instance launch.  User data is supported as long
+  as it's a shell script (starts with #!).  See the tiny-ec2-bootstrap README
+  for more details.  You can still install cloud-init (from the edge testing
   repositories), but we haven't tested whether it will not work correctly for
   this AMI.  If full cloud-init support is important to you please file a bug
   against this project.
 
-- Because several key packages in Alpine 3.8 are missing or lacking features,
-  we currently need to install some packages from edge.  We expect that these
-  will be included in Alpine 3.9.
-  - linux-virt @edge-main (includes necessary ENA drivers)
-  - tiny-ec2-bootstrap @edge-main  (updated to v1.2.0)
-
-- CloudFormation support is still forthcoming. This requires patches and
+- CloudFormation support is still forthcoming.  This requires patches and
   packaging for the upstream cfn tools that have not yet been accepted.
   Eventually full CloudFormation support will be available.

--- a/alpine-ami.yaml
+++ b/alpine-ami.yaml
@@ -3,9 +3,11 @@ variables:
   # NOTE:  Configuration is done with a 'variables.yaml' file.  If it doesn't
   # exist, default configuration is copied from 'variables.yaml-default'.
 
-  # NOTE:  Changing alpine_release may require modifying 'make_ami.sh'.
-  alpine_release: "3.8"
-
+  # NOTE:  Changing arch/version/release may require modifying 'make_ami.sh'.
+  arch: x86_64
+  version: "3.9"
+  release: "3.9.0"
+  revision: ""
 
 builders:
   - type: "amazon-ebssurrogate"
@@ -29,15 +31,15 @@ builders:
         virtualization-type: "hvm"
         root-device-type: "ebs"
         architecture: "x86_64"
-        name: "amzn-ami-hvm-*-x86_64-gp2"
+        name: "amzn2-ami-hvm-2.0.*-gp2"
       owners:
         - "137112412989"
       most_recent: "true"
 
     ### AMI Build Details
 
-    ami_name: "{{user `ami_name_prefix`}}{{user `alpine_release`}}-r{{user `ami_release`}}{{user `ami_name_suffix`}}"
-    ami_description: "{{user `ami_desc_prefix`}}{{user `alpine_release`}}-r{{user `ami_release`}}{{user `ami_desc_suffix`}}"
+    ami_name: "{{user `ami_name_prefix`}}{{user `release`}}{{user `revision`}}-{{user `arch`}}{{user `ami_name_suffix`}}"
+    ami_description: "{{user `ami_desc_prefix`}}{{user `release`}}{{user `revision`}} {{user `arch`}}{{user `ami_desc_suffix`}}"
     ami_virtualization_type: "hvm"
     ami_root_device:
       source_device_name: "/dev/xvdf"
@@ -59,5 +61,10 @@ provisioners:
   - type: "shell"
     script: "make_ami.sh"
     environment_vars:
-      - "ALPINE_RELEASE={{user `alpine_release`}}"
-    execute_command: 'sudo sh -c "{{ .Vars }} {{ .Path }} ''{{user `add_repos`}}'' ''{{user `add_pkgs`}}'' ''{{user `add_svcs`}}''"'
+      - "VERSION={{user `version`}}"
+      - "RELEASE={{user `release`}}"
+      - "REVISION={{user `revision`}}"
+      - "ADD_REPOS='{{user `add_repos`}}'"
+      - "ADD_PKGS='{{user `add_pkgs`}}'"
+      - "ADD_SVCS='{{user `add_svcs`}}'"
+    execute_command: 'sudo sh -c "{{ .Vars }} {{ .Path }}"'

--- a/variables.yaml-default
+++ b/variables.yaml-default
@@ -7,7 +7,7 @@ region:
 # automatically determined.
 subnet:
 
-# Optional security group to apply to the builder instance.
+# Optional security group to apply to the builder instance
 security_group:
 
 # By default, public IPs are assigned (or not) per the subnet's configuration.
@@ -18,25 +18,27 @@ public_ip: ""
 
 ### Build Options ###
 
-# Treat similar to a ABUILD pkgrel variable and increment with every release.
-ami_release: "2"
+# Uncomment/increment every for every rebuild of an Alpine release;
+# re-comment/zero for every new Alpine release
+#revision: "-0"
 
 # AMI name prefix and suffix
-ami_name_prefix: "Alpine-"
-ami_name_suffix: "-EC2"
+ami_name_prefix: "alpine-ami-"
+ami_name_suffix: ""
 
 # AMI description prefix and suffix
 ami_desc_prefix: "Alpine Linux "
-ami_desc_suffix: " Release with EC2 Optimizations"
+ami_desc_suffix: ""
 
-# List of custom lines to add to /etc/apk/repositories.  Note that @edge-main,
-# @edge-community, and @edge-testing repos have been predefined.
+# List of custom lines to add to /etc/apk/repositories
 add_repos:
+#  - "@my-repo http://my-repo.tld/path"
 
 # List of additional packages to add to the AMI.
 add_pkgs:
+#  - package-name
 
-# Additional services to start at the specified level.
+# Additional services to start at the specified level
 add_svcs:
 #  boot:
 #    - service1
@@ -54,7 +56,7 @@ encrypt_ami: "false"
 ami_access:
   - "all"
 
-# List of regions to where the AMI should be copied.
+# List of regions to where the AMI should be copied
 deploy_regions:
   - "us-east-1"
   - "us-east-2"


### PR DESCRIPTION
* Match meanings of 'version' and 'release' to how Alpine uses them
* Use optional 'revision' to denote any same-release AMI rebuild
* Include CPU 'arch' in naming/description (may also offer 'aarch64' AMIs someday)
* Upgrade build instance to use Amazon Linux 2 AMIs
* Use env vars to pass details to `make_ami.sh` instead of via CLI parameters
* `make_ami.sh`
  * minimum version/release shouldn't be overridable
  * update APK tools & Alpine keys
  * check build's release vs. installed `/etc/alpine-release`