### PR TITLE
fix nvme-ebs-links

### DIFF
--- a/nvme/nvme-ebs-links
+++ b/nvme/nvme-ebs-links
@@ -7,7 +7,12 @@ case $ACTION in
     BASE=$(echo $MDEV | sed -re 's/^(nvme[0-9]+n[0-9]+).*/\1/')
     PART=$(echo $MDEV | sed -re 's/nvme[0-9]+n[0-9]+p?//g')
     until [ -n "$EBS" ]; do
-      EBS=$(/usr/sbin/nvme id-ctrl "/dev/$BASE" -b 2>/dev/null | dd bs=32 skip=96 count=1 2>/dev/null | tr -d ' ')
+      EBS=$(
+        /usr/sbin/nvme id-ctrl "/dev/$BASE" -b 2>/dev/null |
+        dd bs=32 skip=96 count=1 2>/dev/null |
+        sed -nre '/^(s|xv)d[a-z]{1,2} +$/p' |
+        tr -d ' '
+      )
     done
     EBS=${EBS#/dev/}$PART
     ln -sf "$MDEV" "${EBS/xvd/sd}"


### PR DESCRIPTION
Ensure that the EBS volume alias matches what we expect it to be.
Should fix issue #40.