### PR TITLE
release 3.9.0-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,27 +25,32 @@ in the not-too-distant future.*
 
 | Alpine Release | Region Code | AMI ID |
 | :------------: | ----------- | ------ |
-| 3.9.0 | ap-northeast-1 | [ami-025126171658214aa](https://ap-northeast-1.console.aws.amazon.com/ec2/home#launchAmi=ami-025126171658214aa) |
-| 3.9.0 | ap-northeast-2 | [ami-05094dd0e72c458fb](https://ap-northeast-2.console.aws.amazon.com/ec2/home#launchAmi=ami-05094dd0e72c458fb) |
-| 3.9.0 | ap-south-1 | [ami-07cb8c31eabcd3b4e](https://ap-south-1.console.aws.amazon.com/ec2/home#launchAmi=ami-07cb8c31eabcd3b4e) |
-| 3.9.0 | ap-southeast-1 | [ami-0928dec71013505b0](https://ap-southeast-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0928dec71013505b0) |
-| 3.9.0 | ap-southeast-2 | [ami-0a5abea120f732aea](https://ap-southeast-2.console.aws.amazon.com/ec2/home#launchAmi=ami-0a5abea120f732aea) |
-| 3.9.0 | ca-central-1 | [ami-08548db765868091d](https://ca-central-1.console.aws.amazon.com/ec2/home#launchAmi=ami-08548db765868091d) |
-| 3.9.0 | eu-central-1 | [ami-0a42df7e65590651e](https://eu-central-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0a42df7e65590651e) |
-| 3.9.0 | eu-north-1 | [ami-08b5a6088d1592e5b](https://eu-north-1.console.aws.amazon.com/ec2/home#launchAmi=ami-08b5a6088d1592e5b) |
-| 3.9.0 | eu-west-1 | [ami-07bf2c996b3bec293](https://eu-west-1.console.aws.amazon.com/ec2/home#launchAmi=ami-07bf2c996b3bec293) |
-| 3.9.0 | eu-west-2 | [ami-07642a3118c43a4e6](https://eu-west-2.console.aws.amazon.com/ec2/home#launchAmi=ami-07642a3118c43a4e6) |
-| 3.9.0 | eu-west-3 | [ami-0916d5db3c81d60ce](https://eu-west-3.console.aws.amazon.com/ec2/home#launchAmi=ami-0916d5db3c81d60ce) |
-| 3.9.0 | sa-east-1 | [ami-0a96fe9195efbba2b](https://sa-east-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0a96fe9195efbba2b) |
-| 3.9.0 | us-east-1 | [ami-00e433019a9c7aa76](https://us-east-1.console.aws.amazon.com/ec2/home#launchAmi=ami-00e433019a9c7aa76) |
-| 3.9.0 | us-east-2 | [ami-029e1787b7a57b032](https://us-east-2.console.aws.amazon.com/ec2/home#launchAmi=ami-029e1787b7a57b032) |
-| 3.9.0 | us-west-1 | [ami-0091bd0c0b9ad4b6b](https://us-west-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0091bd0c0b9ad4b6b) |
-| 3.9.0 | us-west-2 | [ami-0fa1d403af627f066](https://us-west-2.console.aws.amazon.com/ec2/home#launchAmi=ami-0fa1d403af627f066) |
+| 3.9.0-1 | ap-northeast-1 | [ami-0eaff92f5f149a429](https://ap-northeast-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0eaff92f5f149a429) |
+| 3.9.0-1 | ap-northeast-2 | [ami-0def256d4730ba94a](https://ap-northeast-2.console.aws.amazon.com/ec2/home#launchAmi=ami-0def256d4730ba94a) |
+| 3.9.0-1 | ap-south-1 | [ami-026f34bef63412f33](https://ap-south-1.console.aws.amazon.com/ec2/home#launchAmi=ami-026f34bef63412f33) |
+| 3.9.0-1 | ap-southeast-1 | [ami-04a2ad17b9b13d4ec](https://ap-southeast-1.console.aws.amazon.com/ec2/home#launchAmi=ami-04a2ad17b9b13d4ec) |
+| 3.9.0-1 | ap-southeast-2 | [ami-03c7885750c554d30](https://ap-southeast-2.console.aws.amazon.com/ec2/home#launchAmi=ami-03c7885750c554d30) |
+| 3.9.0-1 | ca-central-1 | [ami-0ef17552c0ecbfc4e](https://ca-central-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0ef17552c0ecbfc4e) |
+| 3.9.0-1 | eu-central-1 | [ami-036c913a519569a6d](https://eu-central-1.console.aws.amazon.com/ec2/home#launchAmi=ami-036c913a519569a6d) |
+| 3.9.0-1 | eu-north-1 | [ami-0e86b5fc1e6414006](https://eu-north-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0e86b5fc1e6414006) |
+| 3.9.0-1 | eu-west-1 | [ami-069efddebf851614d](https://eu-west-1.console.aws.amazon.com/ec2/home#launchAmi=ami-069efddebf851614d) |
+| 3.9.0-1 | eu-west-2 | [ami-0aa8ab64c1c6a2a3a](https://eu-west-2.console.aws.amazon.com/ec2/home#launchAmi=ami-0aa8ab64c1c6a2a3a) |
+| 3.9.0-1 | eu-west-3 | [ami-00d39f7e016c2dd2b](https://eu-west-3.console.aws.amazon.com/ec2/home#launchAmi=ami-00d39f7e016c2dd2b) |
+| 3.9.0-1 | sa-east-1 | [ami-028a5b577032629ee](https://sa-east-1.console.aws.amazon.com/ec2/home#launchAmi=ami-028a5b577032629ee) |
+| 3.9.0-1 | us-east-1 | [ami-0b62ea2089812c46b](https://us-east-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0b62ea2089812c46b) |
+| 3.9.0-1 | us-east-2 | [ami-083b8d0f14c76dfd7](https://us-east-2.console.aws.amazon.com/ec2/home#launchAmi=ami-083b8d0f14c76dfd7) |
+| 3.9.0-1 | us-west-1 | [ami-0dd01136582d41914](https://us-west-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0dd01136582d41914) |
+| 3.9.0-1 | us-west-2 | [ami-0efc4434c74bde9fe](https://us-west-2.console.aws.amazon.com/ec2/home#launchAmi=ami-0efc4434c74bde9fe) |
 
 ## Caveats
 
 This image is being used in production but it's still somewhat early stage in
 its development and thus there are some sharp edges.
+
+- As of 3.9.0-1, this AMI starts `haveged` at the boot runlevel, to provide
+  additional initial entropy as discussed in issue #39.  In the long term, we
+  expect the official Alpine Linux kernel configs will be updated to resolve
+  the situation.
 
 - Only EBS-backed HVM instances are supported.  While paravirtualized instances
   are still available from AWS they are not supported on any of the newer

--- a/make_ami.sh
+++ b/make_ami.sh
@@ -142,8 +142,9 @@ install_core_packages() {
     chroot "$target" apk --no-cache add \
         linux-virt \
         alpine-mirrors \
-        nvme-cli \
         chrony \
+        haveged \
+        nvme-cli \
         openssh \
         sudo \
         tiny-ec2-bootstrap \
@@ -240,10 +241,10 @@ enable_services() {
     local target="$1"
     local add_svcs="$2"
 
-    rc_add "$target" default sshd chronyd networking tiny-ec2-bootstrap
-    rc_add "$target" sysinit devfs dmesg mdev hwdrivers
-    rc_add "$target" boot modules hwclock swap hostname sysctl bootmisc syslog acpid
-    rc_add "$target" shutdown killprocs savecache mount-ro
+    rc_add "$target" default chronyd networking sshd tiny-ec2-bootstrap
+    rc_add "$target" sysinit devfs dmesg hwdrivers mdev
+    rc_add "$target" boot acpid bootmisc haveged hostname hwclock modules swap sysctl syslog
+    rc_add "$target" shutdown killprocs mount-ro savecache
 
     if [ -n "$add_svcs" ]; then
         local lvl_svcs; for lvl_svcs in $(echo "$add_svcs" | tr : ' '); do

--- a/release.yaml
+++ b/release.yaml
@@ -1,22 +1,22 @@
-alpine-ami-3.9.0-x86_64:
-  description: "Alpine Linux 3.9.0 x86_64"
-  alpine-release: 3.9.0
+alpine-ami-3.9.0-1-x86_64:
+  description: "Alpine Linux 3.9.0-1 x86_64"
+  alpine-release: 3.9.0-1
   kernel-flavor: virt
-  ami-release-date: "2019-02-06 01:42:52"
+  ami-release-date: "2019-02-24 21:18:47"
   region-identifiers:
-    ap-northeast-1: ami-025126171658214aa
-    ap-northeast-2: ami-05094dd0e72c458fb
-    ap-south-1: ami-07cb8c31eabcd3b4e
-    ap-southeast-1: ami-0928dec71013505b0
-    ap-southeast-2: ami-0a5abea120f732aea
-    ca-central-1: ami-08548db765868091d
-    eu-central-1: ami-0a42df7e65590651e
-    eu-north-1: ami-08b5a6088d1592e5b
-    eu-west-1: ami-07bf2c996b3bec293
-    eu-west-2: ami-07642a3118c43a4e6
-    eu-west-3: ami-0916d5db3c81d60ce
-    sa-east-1: ami-0a96fe9195efbba2b
-    us-east-1: ami-00e433019a9c7aa76
-    us-east-2: ami-029e1787b7a57b032
-    us-west-1: ami-0091bd0c0b9ad4b6b
-    us-west-2: ami-0fa1d403af627f066
+    ap-northeast-1: ami-0eaff92f5f149a429
+    ap-northeast-2: ami-0def256d4730ba94a
+    ap-south-1: ami-026f34bef63412f33
+    ap-southeast-1: ami-04a2ad17b9b13d4ec
+    ap-southeast-2: ami-03c7885750c554d30
+    ca-central-1: ami-0ef17552c0ecbfc4e
+    eu-central-1: ami-036c913a519569a6d
+    eu-north-1: ami-0e86b5fc1e6414006
+    eu-west-1: ami-069efddebf851614d
+    eu-west-2: ami-0aa8ab64c1c6a2a3a
+    eu-west-3: ami-00d39f7e016c2dd2b
+    sa-east-1: ami-028a5b577032629ee
+    us-east-1: ami-0b62ea2089812c46b
+    us-east-2: ami-083b8d0f14c76dfd7
+    us-west-1: ami-0dd01136582d41914
+    us-west-2: ami-0efc4434c74bde9fe

--- a/variables.yaml-default
+++ b/variables.yaml-default
@@ -20,7 +20,7 @@ public_ip: ""
 
 # Uncomment/increment every for every rebuild of an Alpine release;
 # re-comment/zero for every new Alpine release
-#revision: "-0"
+revision: "-1"
 
 # AMI name prefix and suffix
 ami_name_prefix: "alpine-ami-"


### PR DESCRIPTION
Release a revised set of Alpine Linux AMIs, including...

* improved `nvme-ebs-links` mdev script (issue #40)
* start `haveged` at boot runlevel (issue #39)