### PR TITLE
Fix nvme-ebs-links (issue #44)

### DIFF
--- a/nvme/nvme-ebs-links
+++ b/nvme/nvme-ebs-links
@@ -2,26 +2,42 @@
 
 [ -x /usr/sbin/nvme ] || exit
 
+PROC="$(basename $0)[$$]"
+
+log() {
+  FACILITY="kern.$1"
+  shift
+  logger -s -p "$FACILITY" -t "$PROC" "$@"
+}
+
+raw_ebs_alias() {
+  /usr/sbin/nvme id-ctrl "/dev/$BASE" -b 2>/dev/null | dd bs=32 skip=96 count=1 2>/dev/null
+}
+
 case $ACTION in
   add|"")
     BASE=$(echo $MDEV | sed -re 's/^(nvme[0-9]+n[0-9]+).*/\1/')
     PART=$(echo $MDEV | sed -re 's/nvme[0-9]+n[0-9]+p?//g')
+    MAXTRY=50
+    TRY=0
     until [ -n "$EBS" ]; do
-      EBS=$(
-        /usr/sbin/nvme id-ctrl "/dev/$BASE" -b 2>/dev/null |
-        dd bs=32 skip=96 count=1 2>/dev/null |
-        sed -nre '/^(s|xv)d[a-z]{1,2} +$/p' |
-        tr -d ' '
-      )
+      EBS=$(raw_ebs_alias | sed -nre '/^(\/dev\/)?(s|xv)d[a-z]{1,2} /p' | tr -d ' ')
+      [ -n "$EBS" ] && break
+      TRY=$((TRY + 1))
+      if [ $TRY -eq $MAXTRY ]; then
+        log err "Failed to get EBS volume alias for $MDEV after $MAXTRY attempts ($(raw_ebs_alias))"
+        exit 1
+      fi
+      sleep 0.1
     done
     EBS=${EBS#/dev/}$PART
-    ln -sf "$MDEV" "${EBS/xvd/sd}"
-    ln -sf "$MDEV" "${EBS/sd/xvd}"
+    ln -sf "$MDEV" "${EBS/xvd/sd}" && log notice "Added ${EBS/xvd/sd} symlink for $MDEV"
+    ln -sf "$MDEV" "${EBS/sd/xvd}" && log notice "Added ${EBS/sd/xvd} symlink for $MDEV"
     ;;
   remove)
     for TARGET in sd* xvd*
     do
-      [ "$(readlink $TARGET 2>/dev/null)" = "$MDEV" ] && rm -f "$TARGET"
+      [ "$(readlink $TARGET 2>/dev/null)" = "$MDEV" ] && rm -f "$TARGET" && log notice "Removed $TARGET symlink for $MDEV"
     done
     ;;
 esac


### PR DESCRIPTION
* EBS may prepend '/dev/' in front of the EBS alias, adjust the "sanity `sed`" to account for this.
* Attempt to get a sane EBS alias up to 50x, sleep 1/10s in between (max duration ~5 secs).
* Log when we add / fail-to-add / remove EBS alias symlinks.