### PR TITLE
Alpine-3.10.3 (and latest edge)

### DIFF
--- a/packer.conf
+++ b/packer.conf
@@ -27,7 +27,8 @@ builders = [
       {
         volume_type           = "gp2"
         device_name           = "/dev/xvdf"
-        delete_on_termination =  "true"
+        encrypted             = "{{user `ami_encrypt`}}"
+        delete_on_termination = "true"
         volume_size           = "{{user `ami_volume_size`}}"
       }
     ]
@@ -57,7 +58,6 @@ builders = [
       delete_on_termination = "true"
       volume_size           = "{{user `ami_volume_size`}}"
     }
-    encrypt_boot  = "{{user `ami_encrypt`}}"
     ena_support   = "true"
     sriov_support = "true"
     ami_groups    = "{{user `ami_access`}}"

--- a/profiles/version/3.10
+++ b/profiles/version/3.10
@@ -6,7 +6,7 @@ include required("../base/current")
 
 # set version-specific vars
 version     = "3.10"
-release     = "3.10.2"
+release     = "3.10.3"
 end_of_life = "2021-05-01"
 repos {
   "http://dl-cdn.alpinelinux.org/alpine/v3.10/main"      = true

--- a/releases/README.md
+++ b/releases/README.md
@@ -28,27 +28,27 @@ important to you, please open an [issue](https://github.com/mcrute/alpine-ec2-am
 
 ## AMIs
 
-### Alpine Linux 3.10.2 (2019-08-26)
+### Alpine Linux 3.10.3 (2019-10-26)
 <details><summary><i>click to show/hide</i></summary><p>
 
-| Region | alpine-ami-3.10.2-x86_64-r1 |
+| Region | alpine-ami-3.10.3-x86_64-r1 |
 | ------ | --- |
-| ap-northeast-1 | [ami-0865b6aea9d3d4e9a](https://ap-northeast-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0865b6aea9d3d4e9a) ([launch](https://ap-northeast-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0865b6aea9d3d4e9a)) |
-| ap-northeast-2 | [ami-0eb3806a09c62e80a](https://ap-northeast-2.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0eb3806a09c62e80a) ([launch](https://ap-northeast-2.console.aws.amazon.com/ec2/home#launchAmi=ami-0eb3806a09c62e80a)) |
-| ap-south-1 | [ami-03c079c4f6a77bcd8](https://ap-south-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-03c079c4f6a77bcd8) ([launch](https://ap-south-1.console.aws.amazon.com/ec2/home#launchAmi=ami-03c079c4f6a77bcd8)) |
-| ap-southeast-1 | [ami-03cbf9e5c42bd2de0](https://ap-southeast-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-03cbf9e5c42bd2de0) ([launch](https://ap-southeast-1.console.aws.amazon.com/ec2/home#launchAmi=ami-03cbf9e5c42bd2de0)) |
-| ap-southeast-2 | [ami-040ee9c325bd773bb](https://ap-southeast-2.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-040ee9c325bd773bb) ([launch](https://ap-southeast-2.console.aws.amazon.com/ec2/home#launchAmi=ami-040ee9c325bd773bb)) |
-| ca-central-1 | [ami-0aeee1c23a65f09e5](https://ca-central-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0aeee1c23a65f09e5) ([launch](https://ca-central-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0aeee1c23a65f09e5)) |
-| eu-central-1 | [ami-01c4a5f25d39d8c1d](https://eu-central-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-01c4a5f25d39d8c1d) ([launch](https://eu-central-1.console.aws.amazon.com/ec2/home#launchAmi=ami-01c4a5f25d39d8c1d)) |
-| eu-north-1 | [ami-0ac4f026a4624309e](https://eu-north-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0ac4f026a4624309e) ([launch](https://eu-north-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0ac4f026a4624309e)) |
-| eu-west-1 | [ami-073456a92b131bee5](https://eu-west-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-073456a92b131bee5) ([launch](https://eu-west-1.console.aws.amazon.com/ec2/home#launchAmi=ami-073456a92b131bee5)) |
-| eu-west-2 | [ami-04c585868e7f9016e](https://eu-west-2.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-04c585868e7f9016e) ([launch](https://eu-west-2.console.aws.amazon.com/ec2/home#launchAmi=ami-04c585868e7f9016e)) |
-| eu-west-3 | [ami-0196d7c3d0c2e5230](https://eu-west-3.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0196d7c3d0c2e5230) ([launch](https://eu-west-3.console.aws.amazon.com/ec2/home#launchAmi=ami-0196d7c3d0c2e5230)) |
-| sa-east-1 | [ami-0437041273be4d2b3](https://sa-east-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0437041273be4d2b3) ([launch](https://sa-east-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0437041273be4d2b3)) |
-| us-east-1 | [ami-0b13bd8ab9492449c](https://us-east-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0b13bd8ab9492449c) ([launch](https://us-east-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0b13bd8ab9492449c)) |
-| us-east-2 | [ami-0a87fa8a73b9b850c](https://us-east-2.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0a87fa8a73b9b850c) ([launch](https://us-east-2.console.aws.amazon.com/ec2/home#launchAmi=ami-0a87fa8a73b9b850c)) |
-| us-west-1 | [ami-009961e3d2d7ccaa8](https://us-west-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-009961e3d2d7ccaa8) ([launch](https://us-west-1.console.aws.amazon.com/ec2/home#launchAmi=ami-009961e3d2d7ccaa8)) |
-| us-west-2 | [ami-0a083cc95e2bbc4b0](https://us-west-2.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0a083cc95e2bbc4b0) ([launch](https://us-west-2.console.aws.amazon.com/ec2/home#launchAmi=ami-0a083cc95e2bbc4b0)) |
+| ap-northeast-1 | [ami-0760cd78e75cb77a4](https://ap-northeast-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0760cd78e75cb77a4) ([launch](https://ap-northeast-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0760cd78e75cb77a4)) |
+| ap-northeast-2 | [ami-0e749a03d064c1e47](https://ap-northeast-2.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0e749a03d064c1e47) ([launch](https://ap-northeast-2.console.aws.amazon.com/ec2/home#launchAmi=ami-0e749a03d064c1e47)) |
+| ap-south-1 | [ami-0a8839c12787f0c46](https://ap-south-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0a8839c12787f0c46) ([launch](https://ap-south-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0a8839c12787f0c46)) |
+| ap-southeast-1 | [ami-0f0e2be5d8c0110c1](https://ap-southeast-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0f0e2be5d8c0110c1) ([launch](https://ap-southeast-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0f0e2be5d8c0110c1)) |
+| ap-southeast-2 | [ami-0ca4caea0ce1f4a8a](https://ap-southeast-2.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0ca4caea0ce1f4a8a) ([launch](https://ap-southeast-2.console.aws.amazon.com/ec2/home#launchAmi=ami-0ca4caea0ce1f4a8a)) |
+| ca-central-1 | [ami-016d172dee4ff4a22](https://ca-central-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-016d172dee4ff4a22) ([launch](https://ca-central-1.console.aws.amazon.com/ec2/home#launchAmi=ami-016d172dee4ff4a22)) |
+| eu-central-1 | [ami-04e50c8006d4bc2bf](https://eu-central-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-04e50c8006d4bc2bf) ([launch](https://eu-central-1.console.aws.amazon.com/ec2/home#launchAmi=ami-04e50c8006d4bc2bf)) |
+| eu-north-1 | [ami-00207f3df9a9cb088](https://eu-north-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-00207f3df9a9cb088) ([launch](https://eu-north-1.console.aws.amazon.com/ec2/home#launchAmi=ami-00207f3df9a9cb088)) |
+| eu-west-1 | [ami-01c1ec8fdefc61650](https://eu-west-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-01c1ec8fdefc61650) ([launch](https://eu-west-1.console.aws.amazon.com/ec2/home#launchAmi=ami-01c1ec8fdefc61650)) |
+| eu-west-2 | [ami-02520e7e046db5d8f](https://eu-west-2.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-02520e7e046db5d8f) ([launch](https://eu-west-2.console.aws.amazon.com/ec2/home#launchAmi=ami-02520e7e046db5d8f)) |
+| eu-west-3 | [ami-0ef9a828aded0a0de](https://eu-west-3.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0ef9a828aded0a0de) ([launch](https://eu-west-3.console.aws.amazon.com/ec2/home#launchAmi=ami-0ef9a828aded0a0de)) |
+| sa-east-1 | [ami-0ee958f7773223770](https://sa-east-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0ee958f7773223770) ([launch](https://sa-east-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0ee958f7773223770)) |
+| us-east-1 | [ami-063cb098a86c1c4cc](https://us-east-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-063cb098a86c1c4cc) ([launch](https://us-east-1.console.aws.amazon.com/ec2/home#launchAmi=ami-063cb098a86c1c4cc)) |
+| us-east-2 | [ami-0110d80369eb75f49](https://us-east-2.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0110d80369eb75f49) ([launch](https://us-east-2.console.aws.amazon.com/ec2/home#launchAmi=ami-0110d80369eb75f49)) |
+| us-west-1 | [ami-00b06ce695a617956](https://us-west-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-00b06ce695a617956) ([launch](https://us-west-1.console.aws.amazon.com/ec2/home#launchAmi=ami-00b06ce695a617956)) |
+| us-west-2 | [ami-0d0b7768c8cd9a8c8](https://us-west-2.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0d0b7768c8cd9a8c8) ([launch](https://us-west-2.console.aws.amazon.com/ec2/home#launchAmi=ami-0d0b7768c8cd9a8c8)) |
 
 </p></details>
 
@@ -76,26 +76,26 @@ important to you, please open an [issue](https://github.com/mcrute/alpine-ec2-am
 
 </p></details>
 
-### Alpine Linux Edge (2019-08-26)
+### Alpine Linux Edge (2019-10-26)
 <details><summary><i>click to show/hide</i></summary><p>
 
-| Region | alpine-ami-edge-x86_64-20190826015716 |
+| Region | alpine-ami-edge-x86_64-20191026200352 |
 | ------ | --- |
-| ap-northeast-1 | [ami-0aee477cc2cee23cf](https://ap-northeast-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0aee477cc2cee23cf) ([launch](https://ap-northeast-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0aee477cc2cee23cf)) |
-| ap-northeast-2 | [ami-05cbcb200dde2845b](https://ap-northeast-2.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-05cbcb200dde2845b) ([launch](https://ap-northeast-2.console.aws.amazon.com/ec2/home#launchAmi=ami-05cbcb200dde2845b)) |
-| ap-south-1 | [ami-0c3747e69c2496209](https://ap-south-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0c3747e69c2496209) ([launch](https://ap-south-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0c3747e69c2496209)) |
-| ap-southeast-1 | [ami-02f37bdd135ec4d42](https://ap-southeast-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-02f37bdd135ec4d42) ([launch](https://ap-southeast-1.console.aws.amazon.com/ec2/home#launchAmi=ami-02f37bdd135ec4d42)) |
-| ap-southeast-2 | [ami-0463b6ff7b57d9090](https://ap-southeast-2.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0463b6ff7b57d9090) ([launch](https://ap-southeast-2.console.aws.amazon.com/ec2/home#launchAmi=ami-0463b6ff7b57d9090)) |
-| ca-central-1 | [ami-0e4a890b424d67f67](https://ca-central-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0e4a890b424d67f67) ([launch](https://ca-central-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0e4a890b424d67f67)) |
-| eu-central-1 | [ami-092b4f46b7d79af32](https://eu-central-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-092b4f46b7d79af32) ([launch](https://eu-central-1.console.aws.amazon.com/ec2/home#launchAmi=ami-092b4f46b7d79af32)) |
-| eu-north-1 | [ami-042a6066f12f93411](https://eu-north-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-042a6066f12f93411) ([launch](https://eu-north-1.console.aws.amazon.com/ec2/home#launchAmi=ami-042a6066f12f93411)) |
-| eu-west-1 | [ami-04b8b162151a2e45d](https://eu-west-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-04b8b162151a2e45d) ([launch](https://eu-west-1.console.aws.amazon.com/ec2/home#launchAmi=ami-04b8b162151a2e45d)) |
-| eu-west-2 | [ami-0fa5a6db02d8cff64](https://eu-west-2.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0fa5a6db02d8cff64) ([launch](https://eu-west-2.console.aws.amazon.com/ec2/home#launchAmi=ami-0fa5a6db02d8cff64)) |
-| eu-west-3 | [ami-07614b8be5de3b1a0](https://eu-west-3.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-07614b8be5de3b1a0) ([launch](https://eu-west-3.console.aws.amazon.com/ec2/home#launchAmi=ami-07614b8be5de3b1a0)) |
-| sa-east-1 | [ami-09324c8018c018931](https://sa-east-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-09324c8018c018931) ([launch](https://sa-east-1.console.aws.amazon.com/ec2/home#launchAmi=ami-09324c8018c018931)) |
-| us-east-1 | [ami-08f2e440a4fc821b0](https://us-east-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-08f2e440a4fc821b0) ([launch](https://us-east-1.console.aws.amazon.com/ec2/home#launchAmi=ami-08f2e440a4fc821b0)) |
-| us-east-2 | [ami-002f49d922035cd6b](https://us-east-2.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-002f49d922035cd6b) ([launch](https://us-east-2.console.aws.amazon.com/ec2/home#launchAmi=ami-002f49d922035cd6b)) |
-| us-west-1 | [ami-0e146ed2f408cfaee](https://us-west-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0e146ed2f408cfaee) ([launch](https://us-west-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0e146ed2f408cfaee)) |
-| us-west-2 | [ami-052fcb0bc085a75a2](https://us-west-2.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-052fcb0bc085a75a2) ([launch](https://us-west-2.console.aws.amazon.com/ec2/home#launchAmi=ami-052fcb0bc085a75a2)) |
+| ap-northeast-1 | [ami-0112f6ea81c86d5e6](https://ap-northeast-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0112f6ea81c86d5e6) ([launch](https://ap-northeast-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0112f6ea81c86d5e6)) |
+| ap-northeast-2 | [ami-085769ebaedbfdf81](https://ap-northeast-2.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-085769ebaedbfdf81) ([launch](https://ap-northeast-2.console.aws.amazon.com/ec2/home#launchAmi=ami-085769ebaedbfdf81)) |
+| ap-south-1 | [ami-018d0a72b1c1b2923](https://ap-south-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-018d0a72b1c1b2923) ([launch](https://ap-south-1.console.aws.amazon.com/ec2/home#launchAmi=ami-018d0a72b1c1b2923)) |
+| ap-southeast-1 | [ami-0efbcf7df7751898a](https://ap-southeast-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0efbcf7df7751898a) ([launch](https://ap-southeast-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0efbcf7df7751898a)) |
+| ap-southeast-2 | [ami-06dc954ca0af33023](https://ap-southeast-2.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-06dc954ca0af33023) ([launch](https://ap-southeast-2.console.aws.amazon.com/ec2/home#launchAmi=ami-06dc954ca0af33023)) |
+| ca-central-1 | [ami-029fabbc15f6ec893](https://ca-central-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-029fabbc15f6ec893) ([launch](https://ca-central-1.console.aws.amazon.com/ec2/home#launchAmi=ami-029fabbc15f6ec893)) |
+| eu-central-1 | [ami-01353f3799d62f271](https://eu-central-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-01353f3799d62f271) ([launch](https://eu-central-1.console.aws.amazon.com/ec2/home#launchAmi=ami-01353f3799d62f271)) |
+| eu-north-1 | [ami-0787f149b1a3f8194](https://eu-north-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0787f149b1a3f8194) ([launch](https://eu-north-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0787f149b1a3f8194)) |
+| eu-west-1 | [ami-068378748044554e5](https://eu-west-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-068378748044554e5) ([launch](https://eu-west-1.console.aws.amazon.com/ec2/home#launchAmi=ami-068378748044554e5)) |
+| eu-west-2 | [ami-058faf9bf50c5fdc4](https://eu-west-2.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-058faf9bf50c5fdc4) ([launch](https://eu-west-2.console.aws.amazon.com/ec2/home#launchAmi=ami-058faf9bf50c5fdc4)) |
+| eu-west-3 | [ami-0f0bdda8a983eace3](https://eu-west-3.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0f0bdda8a983eace3) ([launch](https://eu-west-3.console.aws.amazon.com/ec2/home#launchAmi=ami-0f0bdda8a983eace3)) |
+| sa-east-1 | [ami-08b88bdd43ac5d063](https://sa-east-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-08b88bdd43ac5d063) ([launch](https://sa-east-1.console.aws.amazon.com/ec2/home#launchAmi=ami-08b88bdd43ac5d063)) |
+| us-east-1 | [ami-0193a17629e6377fc](https://us-east-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-0193a17629e6377fc) ([launch](https://us-east-1.console.aws.amazon.com/ec2/home#launchAmi=ami-0193a17629e6377fc)) |
+| us-east-2 | [ami-03db856d0b5b661ce](https://us-east-2.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-03db856d0b5b661ce) ([launch](https://us-east-2.console.aws.amazon.com/ec2/home#launchAmi=ami-03db856d0b5b661ce)) |
+| us-west-1 | [ami-04864199556e66fad](https://us-west-1.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-04864199556e66fad) ([launch](https://us-west-1.console.aws.amazon.com/ec2/home#launchAmi=ami-04864199556e66fad)) |
+| us-west-2 | [ami-03e59f12dbbee65d4](https://us-west-2.console.aws.amazon.com/ec2/home#Images:visibility=public-images;imageId=ami-03e59f12dbbee65d4) ([launch](https://us-west-2.console.aws.amazon.com/ec2/home#launchAmi=ami-03e59f12dbbee65d4)) |
 
 </p></details>

--- a/releases/alpine.yaml
+++ b/releases/alpine.yaml
@@ -27,6 +27,33 @@ edge-x86_64:
         us-east-2: ami-002f49d922035cd6b
         us-west-1: ami-0e146ed2f408cfaee
         us-west-2: ami-052fcb0bc085a75a2
+    alpine-ami-edge-x86_64-20191026200352:
+      description: Alpine Linux edge x86_64 20191026200352 - https://github.com/mcrute/alpine-ec2-ami
+      profile: alpine
+      profile_build: edge-x86_64
+      version: edge
+      release: edge
+      arch: x86_64
+      revision: '20191026200352'
+      end_of_life: '2019-10-27T20:03:52'
+      build_time: 1572120756
+      artifacts:
+        ap-northeast-1: ami-0112f6ea81c86d5e6
+        ap-northeast-2: ami-085769ebaedbfdf81
+        ap-south-1: ami-018d0a72b1c1b2923
+        ap-southeast-1: ami-0efbcf7df7751898a
+        ap-southeast-2: ami-06dc954ca0af33023
+        ca-central-1: ami-029fabbc15f6ec893
+        eu-central-1: ami-01353f3799d62f271
+        eu-north-1: ami-0787f149b1a3f8194
+        eu-west-1: ami-068378748044554e5
+        eu-west-2: ami-058faf9bf50c5fdc4
+        eu-west-3: ami-0f0bdda8a983eace3
+        sa-east-1: ami-08b88bdd43ac5d063
+        us-east-1: ami-0193a17629e6377fc
+        us-east-2: ami-03db856d0b5b661ce
+        us-west-1: ami-04864199556e66fad
+        us-west-2: ami-03e59f12dbbee65d4
 v3_10-x86_64:
   3.10.0:
     alpine-ami-3.10.0-x86_64-r0:
@@ -139,6 +166,34 @@ v3_10-x86_64:
         us-east-2: ami-0a87fa8a73b9b850c
         us-west-1: ami-009961e3d2d7ccaa8
         us-west-2: ami-0a083cc95e2bbc4b0
+  3.10.3:
+    alpine-ami-3.10.3-x86_64-r1:
+      description: Alpine Linux 3.10.3 x86_64 r1 - https://github.com/mcrute/alpine-ec2-ami
+      profile: alpine
+      profile_build: v3_10-x86_64
+      version: '3.10'
+      release: 3.10.3
+      arch: x86_64
+      revision: r1
+      end_of_life: '2021-05-01T00:00:00'
+      build_time: 1572121673
+      artifacts:
+        ap-northeast-1: ami-0760cd78e75cb77a4
+        ap-northeast-2: ami-0e749a03d064c1e47
+        ap-south-1: ami-0a8839c12787f0c46
+        ap-southeast-1: ami-0f0e2be5d8c0110c1
+        ap-southeast-2: ami-0ca4caea0ce1f4a8a
+        ca-central-1: ami-016d172dee4ff4a22
+        eu-central-1: ami-04e50c8006d4bc2bf
+        eu-north-1: ami-00207f3df9a9cb088
+        eu-west-1: ami-01c1ec8fdefc61650
+        eu-west-2: ami-02520e7e046db5d8f
+        eu-west-3: ami-0ef9a828aded0a0de
+        sa-east-1: ami-0ee958f7773223770
+        us-east-1: ami-063cb098a86c1c4cc
+        us-east-2: ami-0110d80369eb75f49
+        us-west-1: ami-00b06ce695a617956
+        us-west-2: ami-0d0b7768c8cd9a8c8
 v3_9-x86_64:
   3.9.4:
     alpine-ami-3.9.4-x86_64-r0:


### PR DESCRIPTION
Also includes fix for Packer regression affecting encrypted AMIs