### PR TITLE
Support ARM instance types

### DIFF
--- a/profiles/alpine.conf
+++ b/profiles/alpine.conf
@@ -6,6 +6,7 @@ version-3_10  { include required("version/3.10") }
 version-3_9   { include required("version/3.9") }
 version-edge  { include required("version/edge") }
 arch-x86_64   { include required("arch/x86_64") }
+arch-aarch64  { include required("arch/aarch64") }
 
 # profile vars
 alpine {
@@ -19,6 +20,10 @@ BUILDS {
   v3_10-x86_64  = ${version-3_10} ${arch-x86_64} ${alpine}
   v3_9-x86_64   = ${version-3_9}  ${arch-x86_64} ${alpine}
   edge-x86_64   = ${version-edge} ${arch-x86_64} ${alpine} {
+    revision = "@NOW@"
+  }
+
+  edge-aarch64 = ${version-edge} ${arch-aarch64} ${alpine} {
     revision = "@NOW@"
   }
 }

--- a/profiles/base/1
+++ b/profiles/base/1
@@ -33,6 +33,7 @@ ami_desc_suffix = ""
 ami_volume_size = "1"
 ami_encrypt     = "false"
 ami_user        = "alpine"  # modification currently not supported
+
 # NOTE: the following are python format strings, resolved in resolve-profile.py
 ami_name        = "{var.ami_name_prefix}{var.release}-{var.arch}-{var.revision}{var.ami_name_suffix}"
 ami_desc        = "{var.ami_desc_prefix}{var.release} {var.arch} {var.revision}{var.ami_desc_suffix}"
@@ -86,10 +87,12 @@ kernel_modules {
   sd-mod      = true
   usb-storage = true
   ext4        = true
+  nvme        = true
+  ena         = true
 }
 kernel_options {
-  "console=ttyS0" = true
-  "console=tty0"  = true
+  "console=ttyS0,115200n8"          = true
+  "nvme_core.io_timeout=4294967295" = true
 }
 # NOTE: nvme and ena are critical for i3, a1, m6g, and anything in the 5 series
 # forward. Without them these instances will not boot.

--- a/profiles/test.conf
+++ b/profiles/test.conf
@@ -23,6 +23,7 @@ BUILDS {
   edge-x86_64   = ${version-edge} ${arch-x86_64} ${test}
 
   # aarch64 AMI builds are under development
+  edge-aarch64 = ${version-edge} ${arch-aarch64} ${test}
   #edge-aarch64 = ${version-edge} ${arch-aarch64} ${test} {
   #   other us-west-2 subnet doesn't do a1.* instances
   #  build_subnet = "subnet-08dfc622745f7d96a"

--- a/scripts/setup-ami
+++ b/scripts/setup-ami
@@ -59,7 +59,7 @@ fetch_apk_tools() {
 
 # mostly from Alpine's /sbin/setup-disk
 setup_partitions() {
-    start=1M    # TODO: do we really need to waste 1M?
+    start=2M # Needed to align EBS partitions
     line=
 
     # create new partitions
@@ -70,7 +70,7 @@ setup_partitions() {
             *) echo "$start,$line"; start= ;;
             esac
         done
-    ) | sfdisk --quiet --label dos "$DEVICE"
+    ) | sfdisk --quiet --label gpt "$DEVICE"
 
     # we assume that the build host will create the new devices within 5s
     tries=5
@@ -87,7 +87,7 @@ make_filesystem() {
 
     if [ "$BOOTLOADER" = 'grub-efi' ]; then
         # create a small EFI partition (remainder for root), and mount it
-        setup_partitions '5M,EF' ',L'
+        setup_partitions '5M,U,*' ',L'
         root_dev="${DEVICE}2"
         mkfs.vfat -n EFI "${DEVICE}1"
     fi
@@ -142,9 +142,15 @@ install_core_packages() {
     # EC2 console.
     sed -Ei '/^tty[0-9]/s/^/#/' "$TARGET/etc/inittab"
 
+    # Enable the getty for the serial terminal. This will show the login prompt
+    # in the get-console-output API that's accessible by the CLI and the web
+    # console.
+    sed -Ei '/^#ttyS0:/s/^#//' "$TARGET/etc/inittab"
+
     # Make it a little more obvious who is logged in by adding username to the
     # prompt
     sed -i "s/^export PS1='/&\\\\u@/" "$TARGET/etc/profile"
+
 }
 
 setup_mdev() {
@@ -196,7 +202,6 @@ install_extlinux() {
     chroot "$TARGET" /sbin/update-extlinux --warn-only
 }
 
-# TODO: this isn't quite working for some reason
 install_grub_efi() {
     case "$ARCH" in
         x86_64)     grub_target=x86_64-efi ; fwa=x64 ;;
@@ -209,16 +214,17 @@ install_grub_efi() {
         --bootloader-id=alpine --boot-directory=/boot --no-nvram
 
     # fallback mode
-    install -D "$TARGET/boot/efi/EFI/alpine/grub$fwa.efi" "$TARGET/boot/efi/EFI/boot/$fwa.efi"
+    install -D "$TARGET/boot/efi/EFI/alpine/grub$fwa.efi" "$TARGET/boot/efi/EFI/boot/boot$fwa.efi"
 
-    # add cmdline linux defaults to /etc/default/grub
-    echo "GRUB_CMDLINE_LINUX_DEFAULT=\"modules=$KERNEL_MODS $KERNEL_OPTS\"" >> "$TARGET"/etc/default/grub
-
-    # eliminate grub pause
-    sed -ie 's/^GRUB_TIMEOUT=.$/GRUB_TIMEOUT=0/' "$TARGET/etc/default/grub"
+    cat > "$TARGET/etc/default/grub" <<- EOF
+	GRUB_TIMEOUT=0
+	GRUB_DISABLE_SUBMENU=y
+	GRUB_DISABLE_RECOVERY=true
+	GRUB_SERIAL_COMMAND="serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"
+	GRUB_CMDLINE_LINUX_DEFAULT="modules=$KERNEL_MODS $KERNEL_OPTS"
+	EOF
 
     # generate/install new config
-    [ -e "$TARGET/boot/grub/grub.cfg" ] && cp "$TARGET/boot/grub/grub.cfg" "$TARGET/boot/grub/grub.cfg.backup"
     chroot "$TARGET" grub-mkconfig -o /boot/grub/grub.cfg
 }
 


### PR DESCRIPTION
This depends on the `template-updates` in #67 

The magic numbers for console speed, nvme timeout, and block offset all come from the Amazon Linux and Ubuntu AMIs.

We'll want to remove the `install_updated_aarch64_kernel` function once the upstream virt kernel has the ena patches. This should be within the next day or so for edge and in the 3.12 release. I'll push some changes to this to integrate the test profile into the alpine one but wanted to get this out for review as soon as it was cleaned up.