### PR TITLE
Optional AWS Profile & Cross-Account Access

### DIFF
--- a/packer.conf
+++ b/packer.conf
@@ -4,7 +4,8 @@
 
 builders = [
   {
-    type = "amazon-ebssurrogate"
+    type    = "amazon-ebssurrogate"
+    profile = "{{user `aws_profile`}}"
 
     ### Builder Instance Details
 
@@ -60,6 +61,7 @@ builders = [
     }
     ena_support   = "true"
     sriov_support = "true"
+    ami_users     = "{{user `aws_users`}}"
   }
 ]
 

--- a/profiles/base/1
+++ b/profiles/base/1
@@ -26,6 +26,8 @@ build_ami_owner       = "137112412989"
 build_ami_latest      = "true"
 
 # AMI build/deploy
+aws_profile     = null  # AWS profile to build AMI
+aws_accounts    = null  # comma-separated AWS accounts allowed to launch AMI
 ami_name_prefix = "alpine-ami-"
 ami_name_suffix = ""
 ami_desc_prefix = "Alpine Linux "


### PR DESCRIPTION
Allows encoding of the AWS profile to use in the build profile, and enabling the built AMI with a list of AWS accounts that are allowed access.