### PR TITLE
Optional Additional Setup

### DIFF
--- a/packer.conf
+++ b/packer.conf
@@ -90,6 +90,7 @@ provisioners = [
       "KERNEL_MODS={{user `kernel_modules`}}"
       "KERNEL_OPTS={{user `kernel_options`}}"
       "INITFS_FEATURES={{user `initfs_features`}}"
+      "EC2_USER={{user `ami_user`}}"
     ]
     use_env_var_file = "true"
     execute_command = "sudo sh -c '. {{.EnvVarFile}} && {{.Path}}'"

--- a/packer.conf
+++ b/packer.conf
@@ -69,8 +69,8 @@ builders = [
 provisioners = [
   {
     type        = "file"
-    source      = "../scripts/nvme-ebs-links"
-    destination = "/tmp/nvme-ebs-links"
+    source      = "./profile/{{user `profile`}}/{{user `profile_build`}}/setup-ami.d"
+    destination = "/tmp/setup-ami.d"
   }
   {
     type    = "shell"

--- a/profiles/base/2
+++ b/profiles/base/2
@@ -34,7 +34,7 @@ ami_desc_prefix = "Alpine Linux "
 ami_desc_suffix = ""
 ami_volume_size = "1"
 ami_encrypt     = "false"
-ami_user        = "alpine"  # modification currently not supported
+ami_user        = "alpine"
 
 # NOTE: the following are python format strings, resolved in resolve-profile.py
 ami_name        = "{var.ami_name_prefix}{var.release}-{var.arch}-{var.revision}{var.ami_name_suffix}"
@@ -95,9 +95,18 @@ kernel_options {
   "console=ttyS0,115200n8"          = true
   "nvme_core.io_timeout=4294967295" = true
 }
-# NOTE: nvme and ena are critical for i3, a1, m6g, and anything in the 5 series
-# forward. Without them these instances will not boot.
+# NOTE: nvme and ena are critical for i3, a1, m6g, and anything in the 5
+# series forward.  Without them these instances will not boot.
 initfs_features {
   nvme        = true
   ena         = true
 }
+
+# Local path to additional setup script, runs before setup-ami cleanup.
+setup_script = null
+
+# Files/directories to copy to /tmp/setup-ami.d/ on build instance for
+# setup-script to use.  Map key is the copy target in the build instance
+# /tmp/setup-ami.d/ directory, map value is local file/directory path.
+# Nothing copied ends up in the AMI unless `setup_script` does it.
+setup_copy = null

--- a/profiles/test.conf
+++ b/profiles/test.conf
@@ -1,6 +1,7 @@
 ### Profile for Testing Builds
 # vim: ts=2 et:
 
+version-3_12  { include required("version/3.12") }
 version-3_11  { include required("version/3.11") }
 version-3_10  { include required("version/3.10") }
 version-3_9   { include required("version/3.9") }
@@ -12,20 +13,18 @@ arch-aarch64  { include required("arch/aarch64") }
 test {
   ami_name_prefix = "test-"
   ami_desc_prefix = "Alpine Test "
+  ami_user        = "test"
 }
 
 # Build definitions
 BUILDS {
   # merge version, arch, profile, and build vars
-  v3_11-x86_64  = ${version-3_11} ${arch-x86_64} ${test}
-  v3_10-x86_64  = ${version-3_10} ${arch-x86_64} ${test}
-  v3_9-x86_64   = ${version-3_9}  ${arch-x86_64} ${test}
+  v3_12-x86_64  = ${version-3_12} ${arch-x86_64} ${test} { revision = "r0" }
+  v3_11-x86_64  = ${version-3_11} ${arch-x86_64} ${test} { revision = "r0" }
+  v3_10-x86_64  = ${version-3_10} ${arch-x86_64} ${test} { revision = "r0" }
+  v3_9-x86_64   = ${version-3_9}  ${arch-x86_64} ${test} { revision = "r0" }
   edge-x86_64   = ${version-edge} ${arch-x86_64} ${test}
 
-  # aarch64 AMI builds are under development
-  edge-aarch64 = ${version-edge} ${arch-aarch64} ${test}
-  #edge-aarch64 = ${version-edge} ${arch-aarch64} ${test} {
-  #   other us-west-2 subnet doesn't do a1.* instances
-  #  build_subnet = "subnet-08dfc622745f7d96a"
-  #}
+  v3_12-aarch64 = ${version-3_12} ${arch-aarch64} ${test} { revision = "r0" }
+  edge-aarch64  = ${version-edge} ${arch-aarch64} ${test}
 }

--- a/profiles/version/3.12
+++ b/profiles/version/3.12
@@ -7,7 +7,7 @@ include required("../base/1")
 # set version-specific vars
 version     = "3.12"
 release     = "3.12.0"
-end_of_life = "2022-06-01"
+end_of_life = "2022-05-01"
 repos {
   "http://dl-cdn.alpinelinux.org/alpine/v3.12/main"      = true
   "http://dl-cdn.alpinelinux.org/alpine/v3.12/community" = true

--- a/scripts/builder.py
+++ b/scripts/builder.py
@@ -534,11 +534,11 @@ class ConfigBuilder:
             self.rel_symlink("scripts/nvme-ebs-links", setup_dir, "nvme-ebs-links")
 
             # symlink additional setup_script
-            if "setup_script" in cfg.keys():
+            if "setup_script" in cfg.keys() and cfg["setup_script"] is not None:
                 self.rel_symlink(cfg["setup_script"], setup_dir, "setup_script")
                 del cfg["setup_script"]
 
-            if "setup_copy" in cfg.keys():
+            if "setup_copy" in cfg.keys() and cfg["setup_copy"] is not None:
                 for dst, src in cfg["setup_copy"].items():
                     self.rel_symlink(src, setup_dir, dst)
                 del cfg["setup_copy"]

--- a/scripts/setup-ami
+++ b/scripts/setup-ami
@@ -154,7 +154,7 @@ install_core_packages() {
 }
 
 setup_mdev() {
-    cp /tmp/nvme-ebs-links "$TARGET/lib/mdev"
+    cp /tmp/setup-ami.d/nvme-ebs-links "$TARGET/lib/mdev"
 
     # insert nvme ebs mdev configs just above "# fallback" comment
     sed -n -i \
@@ -288,6 +288,19 @@ configure_ntp() {
         -i "$TARGET/etc/chrony/chrony.conf"
 }
 
+setup_script() {
+    if [ -f /tmp/setup-ami.d/setup_script ]; then
+        einfo "Executing additional setup script"
+        (
+            cd /tmp/setup-ami.d
+            chmod u+x ./setup_script
+            TARGET="$TARGET" ./setup_script
+        )
+    else
+        einfo "No additional setup script"
+    fi
+}
+
 cleanup() {
     # Sweep cruft out of the image that doesn't need to ship or will be
     # re-generated when the image boots
@@ -343,6 +356,8 @@ main() {
     enable_services
     create_alpine_user
     configure_ntp
+
+    setup_script
 
     einfo "All done, cleaning up"
     cleanup

--- a/scripts/setup-ami
+++ b/scripts/setup-ami
@@ -256,8 +256,6 @@ enable_services() {
     done
 }
 
-# TODO: allow profile to specify alternate ALPINE_USER?
-# NOTE: tiny-ec2-bootstrap will need to be updated to support that!
 create_alpine_user() {
     # Allow members of the wheel group to sudo without a password. By default
     # this will only be the alpine user. This allows us to ship an AMI that is
@@ -269,12 +267,17 @@ create_alpine_user() {
     # There is no real standard ec2 username across AMIs, Amazon uses ec2-user
     # for their Amazon Linux AMIs but Ubuntu uses ubuntu, Fedora uses fedora,
     # etc... (see: https://alestic.com/2014/01/ec2-ssh-username/). So our user
-    # and group are alpine because this is Alpine Linux. On instance bootstrap
-    # the user can create whatever users they want and delete this one.
-    chroot "$TARGET" /usr/sbin/addgroup alpine
-    chroot "$TARGET" /usr/sbin/adduser -h /home/alpine -s /bin/sh -G alpine -D alpine
-    chroot "$TARGET" /usr/sbin/addgroup alpine wheel
-    chroot "$TARGET" /usr/bin/passwd -u alpine
+    # and group, by default, are alpine because this is Alpine Linux.
+    user="${EC2_USER:-alpine}"
+    chroot "$TARGET" /usr/sbin/addgroup "$user"
+    chroot "$TARGET" /usr/sbin/adduser -h "/home/$user" -s /bin/sh -G "$user" -D "$user"
+    chroot "$TARGET" /usr/sbin/addgroup "$user" wheel
+    chroot "$TARGET" /usr/bin/passwd -u "$user"
+
+    # Let tiny-ec2-bootstrap know what the EC2 user of the AMI is
+    cat > "$TARGET/etc/conf.d/tiny-ec2-bootstrap" <<EOF
+EC2_USER="$user"
+EOF
 }
 
 configure_ntp() {


### PR DESCRIPTION
Profiles can specify `setup_script` to do additional things.  If additional files/dirs are required, a `setup_copy` map will copy them to the build instance so that `setup_script` can use/install them.

Also implements `ami_user` allowing profiles to change the AMI user from the default, "alpine".