### PR TITLE
Fix assembly of /etc/network/interfaces

### DIFF
--- a/scripts/setup-ami
+++ b/scripts/setup-ami
@@ -245,6 +245,9 @@ setup_networking() {
         "$SETUP/etc/interfaces.d/"*
     cat "$IFACE_CFG.d/lo" "$IFACE_CFG.d/eth0" > "$IFACE_CFG"
 
+    install -o root -g root -Dm755 -t "$TARGET/etc/network" \
+        "$SETUP/assemble-interfaces"
+
     # install ucdhcp hooks for EC2 ENI IPv6 and secondary IPv4
     install -o root -g root -Dm755 -t "$TARGET/usr/share/udhcpc" \
         "$SETUP/eth-eni-hook"

--- a/scripts/setup-ami.d/assemble-interfaces
+++ b/scripts/setup-ami.d/assemble-interfaces
@@ -1,0 +1,42 @@
+#!/bin/sh
+# vim: set ts=4 et:
+
+set -e
+
+IFACE_CFG=/etc/network/interfaces
+IFACE_DIR="${IFACE_CFG}.d"
+
+cd "$IFACE_DIR"
+
+cat > "$IFACE_CFG.new" <<EOT
+# NOTE: /etc/network/assemble-interfaces rewrites this file.  Edit files in
+#       /etc/network/interfaces.d/ to persist any customizations.
+
+EOT
+
+# loopback first
+cat lo >> "$IFACE_CFG.new"
+
+# existing eths
+for i in /sys/class/net/eth*; do
+    IFACE="$(basename "$i")"
+    [ ! -f "$IFACE" ] && sed -e "s/%%/$IFACE/g" DEFAULT > "$IFACE"
+    cat "$IFACE" >> "$IFACE_CFG.new"
+done
+
+# all the rest
+for i in "$IFACE_DIR"/*; do
+    IFACE="$(basename "$i")"
+    case $IFACE in
+        DEFAULT|lo|eth*)
+            continue
+            ;;
+        *)
+            cat "$IFACE" >> "$IFACE_CFG.new"
+            ;;
+    esac
+done
+
+# install new interfaces config
+cp -a "$IFACE_CFG" "$IFACE_CFG.bak"
+mv "$IFACE_CFG.new" "$IFACE_CFG"

--- a/scripts/setup-ami.d/etc/interfaces.d/lo
+++ b/scripts/setup-ami.d/etc/interfaces.d/lo
@@ -1,6 +1,3 @@
-# NOTE: /lib/mdev/eth-eni-hotplug rewrites this file.  Edit files in
-#       /etc/network/interfaces.d/ to persist any customizations.
-
 auto lo
 iface lo inet loopback
 

--- a/scripts/setup-ami.d/eth-eni-hotplug
+++ b/scripts/setup-ami.d/eth-eni-hotplug
@@ -23,7 +23,6 @@ RTABLE="${MDEV#eth}"
 let RTABLE+=1000
 
 IFACE_CFG=/etc/network/interfaces
-IFACE_DIR="${IFACE_CFG}.d"
 
 ip() {
     v=-4
@@ -42,15 +41,7 @@ ip() {
 
 assemble_interfaces() {
     log info "Rebuilding $IFACE_CFG"
-    cd "$IFACE_DIR"
-    cat lo > "$IFACE_CFG.new"
-    for i in /sys/class/net/eth*; do
-        IFACE="$(basename "$i")"
-        [ ! -f "$IFACE" ] && sed -e "s/%%/$IFACE/g" DEFAULT > "$IFACE"
-        cat "$IFACE" >> "$IFACE_CFG.new"
-    done
-    cp -a "$IFACE_CFG" "$IFACE_CFG.bak"
-    mv "$IFACE_CFG.new" "$IFACE_CFG"
+    /etc/network/assemble-interfaces
 }
 
 interface_up() {

--- a/scripts/setup-ami.d/eth-eni-setup
+++ b/scripts/setup-ami.d/eth-eni-setup
@@ -2,35 +2,15 @@
 
 description="Sets up interfaces for attached Elastic Network Interfaces"
 
-IFACE_CFG=/etc/network/interfaces
-
 depend() {
 	before net
 	need sysfs
-}
-
-eni_eths() {
-	local iface
-	for iface in /sys/class/net/eth*; do
-		echo "${iface##*/}"
-	done
 }
 
 start() {
 	local iface
 
 	ebegin "Setting up interfaces for attached ENIs"
-
-	cat "$IFACE_CFG.d/lo" > "$IFACE_CFG.new"
-
-	for iface in $(eni_eths); do
-		[ -f "$IFACE_CFG.d/$iface" ] ||
-			sed -e "s/%%/$iface/g" "$IFACE_CFG.d/DEFAULT" > "$IFACE_CFG.d/$iface"
-		cat "$IFACE_CFG.d/$iface" >> "$IFACE_CFG.new"
-		einfo "$iface configured"
-	done
-
-	mv "$IFACE_CFG.new" "$IFACE_CFG"
-
+  /etc/network/assemble-interfaces
 	eend "$?"
 }


### PR DESCRIPTION
Include the other interface configs from /etc/network/interfaces.d/ after `lo` and existing `eth*`, as was initially intended.

Also separate out the assembly code into its own script, as this is done both on boot via `eth-eni-setup` and on hotplug events by `eth-eni-hotplug`.

Resolves #91