### PR TITLE
Post-Build Cleanup, etc.

### DIFF
--- a/releases/README_alpine.md
+++ b/releases/README_alpine.md
@@ -1,0 +1,1 @@
+README.md


### PR DESCRIPTION
**scripts/builder.py**...

GenReleaseReadme:
* combine with ReleaseReadmeUpdater
* generates `README_<profile>.md`
* `README_alpine.md` is a symlink to `README.md`
* don't crash when README doesn't preexist
* append image list to README if no list found to replace

MakeAMIs:
* collect all artifact IDs and report after all builds
* don't update releases/readme

PruneAMIs:
* defaults to pretend mode, unless `--no-pretend`
* improve readability

UpdateReleases:
* replace code with what was RefreshReleases