### PR TITLE
Autodetect Current Revision of Alpine Version

### DIFF
--- a/profiles/base/1
+++ b/profiles/base/1
@@ -8,7 +8,7 @@ revision      = "r0"
 
 # Versioning
 version     = null
-release     = null
+release     = null    # defaults to autodetect
 end_of_life = null
 
 # Architecture

--- a/profiles/base/2
+++ b/profiles/base/2
@@ -8,7 +8,7 @@ revision      = "r0"
 
 # Versioning
 version     = null
-release     = null
+release     = null    # defaults to autodetect
 end_of_life = null
 
 # Architecture

--- a/profiles/test.conf
+++ b/profiles/test.conf
@@ -1,6 +1,7 @@
 ### Profile for Testing Builds
 # vim: ts=2 et:
 
+version-3_13  { include required("version/3.13") }
 version-3_12  { include required("version/3.12") }
 version-3_11  { include required("version/3.11") }
 version-3_10  { include required("version/3.10") }
@@ -25,11 +26,13 @@ test {
 # Build definitions
 BUILDS {
   # merge version, arch, profile, and build vars
+  v3_13-x86_64  = ${version-3_13} ${arch-x86_64} ${test}
   v3_12-x86_64  = ${version-3_12} ${arch-x86_64} ${test}
   v3_11-x86_64  = ${version-3_11} ${arch-x86_64} ${test} { revision = "r1" }
   v3_10-x86_64  = ${version-3_10} ${arch-x86_64} ${test} { revision = "r2" }
   edge-x86_64   = ${version-edge} ${arch-x86_64} ${test}
 
+  v3_13-aarch64 = ${version-3_13} ${arch-aarch64} ${test}
   v3_12-aarch64 = ${version-3_12} ${arch-aarch64} ${test}
   edge-aarch64  = ${version-edge} ${arch-aarch64} ${test}
 }

--- a/profiles/version/3.10
+++ b/profiles/version/3.10
@@ -6,7 +6,6 @@ include required("../base/1")
 
 # set version-specific vars
 version     = "3.10"
-release     = "3.10.5"
 end_of_life = "2021-05-01"
 repos {
   "http://dl-cdn.alpinelinux.org/alpine/v3.10/main"      = true

--- a/profiles/version/3.11
+++ b/profiles/version/3.11
@@ -6,7 +6,6 @@ include required("../base/1")
 
 # set version-specific vars
 version     = "3.11"
-release     = "3.11.7"
 end_of_life = "2021-11-01"
 repos {
   "http://dl-cdn.alpinelinux.org/alpine/v3.11/main"      = true

--- a/profiles/version/3.12
+++ b/profiles/version/3.12
@@ -6,7 +6,6 @@ include required("../base/1")
 
 # set version-specific vars
 version     = "3.12"
-release     = "3.12.3"
 end_of_life = "2022-05-01"
 repos {
   "http://dl-cdn.alpinelinux.org/alpine/v3.12/main"      = true

--- a/profiles/version/3.13
+++ b/profiles/version/3.13
@@ -6,7 +6,6 @@ include required("../base/current")
 
 # add edge-specific tweaks...
 version     = "3.13"
-release     = "3.13.1"
 end_of_life = "2022-11-01"
 
 repos {

--- a/profiles/version/3.9
+++ b/profiles/version/3.9
@@ -6,7 +6,6 @@ include required("../base/1")
 
 # set version-specific vars
 version     = "3.9"
-release     = "3.9.6"
 end_of_life = "2021-01-01"
 repos {
   "http://dl-cdn.alpinelinux.org/alpine/v3.9/main"      = true

--- a/profiles/version/edge
+++ b/profiles/version/edge
@@ -6,7 +6,6 @@ include required("../base/current")
 
 # add edge-specific tweaks...
 version     = "edge"
-release     = "edge"
 end_of_life = null      # defaults to tomorrow
 revision    = null      # defaults to datetime
 

--- a/scripts/setup-ami
+++ b/scripts/setup-ami
@@ -122,7 +122,7 @@ install_base() {
     if [ "$VERSION" != edge ]; then
         ALPINE_RELEASE=$(cat "$TARGET/etc/alpine-release")
         [ "$RELEASE" = "$ALPINE_RELEASE" ] || \
-            die "Newer Alpine release detected: $ALPINE_RELEASE"
+            die "Release '$RELEASE' does not match /etc/alpine-release: $ALPINE_RELEASE"
     fi
 }
 


### PR DESCRIPTION
* continue to use provided 'release' value if specified
* continue to use 'edge' for edge versions
* deduce 'release' value from the version on the alpine-base APK in https:\/\/dl-cdn.alpinelinux.org/alpine/v\<version\>/main/\<arch\>/ 
* update test profile with 3.13

Resolves #112 